### PR TITLE
[BKR-219] UseIERC4626.withdrawVault does not check if vault is address(0) Q2

### DIFF
--- a/contracts/core/hooks/UseIERC4626.sol
+++ b/contracts/core/hooks/UseIERC4626.sol
@@ -138,6 +138,8 @@ abstract contract UseIERC4626 is GovernableOwnable {
     address receiver,
     address owner
   ) internal virtual returns (uint256 shares) {
+    // Check if the vault address is valid
+    if (address(vault) == address(0)) revert InvalidVaultAddress();
     // Call the withdraw function of the vault to withdraw assets
     shares = vault.withdraw(assets, receiver, owner);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@baker-fi/sdk",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@baker-fi/sdk",
-      "version": "1.4.0-beta.1",
+      "version": "1.4.0-beta.3",
       "license": "ISC",
       "dependencies": {
         "@taikai/dappkit": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baker-fi/sdk",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.3",
   "description": "",
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",


### PR DESCRIPTION
While other functions check if the vault parameter is address(0), UseIERC4626.withdrawVault does not check if vault is address(0).